### PR TITLE
Fix broken example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ Then you need to add some configuration to `config.toml`, please flow the [Site 
 
 ```toml
 [params]
-  defaultCover = 'https://example.com/cover.jpg' // default cover image for post not setting cover
-  email = 'floyd.li@outlook.com' // the email address display in the footer
-  [[params.socialMedia]] // custom social links display in the footer, you can add one or more
+  defaultCover = 'https://example.com/cover.jpg' # default cover image for post not setting cover
+  email = 'floyd.li@outlook.com' # the email address display in the footer
+  [[params.socialMedia]] # custom social links display in the footer, you can add one or more
     name = 'Github'
     url = 'https://github.com/floyd-li'
   [[params.socialMedia]]
     name = 'Twitter'
     url = 'https://twitter.com/some-one'
-  [[params.blogroll]] // blogroll links display in the footer, you can add one or more
+  [[params.blogroll]] # blogroll links display in the footer, you can add one or more
     name = 'Apple'
     url = 'https://Apple.com/'
   [[params.blogroll]]


### PR DESCRIPTION
## Problem

🔴 When copying the example config from the readme I was unable to successfully run hugo server, it complained with this error:

> ERROR 2023/03/12 14:19:04 Failed to reload config: "c:\workspace\hugo\my-itheme-site\config.toml:12:34": unmarshal failed: toml: expected newline but got U+002F '/'

Took me a while to realize that the comments with `//` were causing syntax errors.

**Note:** I didn't use the `exampleSite` because I was changing the theme of an existing hugo site.

## Solution

I changed them to `#` instead and it was able to handle comments.