### PR TITLE
Rel image path

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,5 +1,12 @@
 
-{{ $sign := md5 .Destination}}
+{{- $src := .Destination -}}
+
+{{- with dict "Path" $src "Resources" .Page.Resources | partial "function/resource.html" -}}
+    {{- $src = .RelPermalink -}}
+{{- end -}}
+
+{{ $sign := md5 $src}}
+
 
 {{ $str := split .Text "|" }}
 
@@ -11,7 +18,7 @@
     <div class="image-sharesheet">
       <div class="image image-load image-asset image-{{ $sign }}" id="lht{{ $sign }}">
         <picture  class="picture">
-          <img class="picture-image" data-src="{{ .Destination | safeURL }}" alt="{{ .Text }}"  />
+          <img class="picture-image" data-src="{{ $src  | safeURL }}" alt="{{ .Text }}"  />
         </picture>
       </div>
     </div>

--- a/layouts/partials/function/resource.html
+++ b/layouts/partials/function/resource.html
@@ -1,0 +1,16 @@
+{{- $resource := 0 -}}
+{{- $url := urls.Parse .Path -}}
+{{- if not $url.Host | and $url.Path | and (strings.HasSuffix $url.Path "/" | not) -}}
+    {{- if .Resources -}}
+        {{- with .Resources.GetMatch $url.Path -}}
+            {{- $resource = . -}}
+        {{- end -}}
+    {{- end -}}
+    {{- if not $resource -}}
+        {{- with resources.Get $url.Path -}}
+            {{- $resource = . -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{- return $resource -}}

--- a/layouts/partials/moreTile.html
+++ b/layouts/partials/moreTile.html
@@ -16,7 +16,11 @@
     aria-label={label}
   >
     <div class="tile__media" aria-hidden="true">
-      <img class="cover image" data-src="{{ if .context.Params.cover }}{{ .context.Params.cover }}{{ else }}{{ site.Params.defaultCover }}{{ end }}" alt="lt"/>
+      {{- $src := .context.Params.cover | default site.Params.defaultCover -}}
+      {{- with .context.Resources.GetMatch (printf "%s" ($src)) -}}
+          {{- $src = .RelPermalink -}}
+      {{- end -}}
+      <img class="cover image" data-src="{{ $src }}" alt="lt"/>
     </div>
     <div class="tile__description" aria-hidden="true">
       <div class="tile__head">

--- a/layouts/partials/tile.html
+++ b/layouts/partials/tile.html
@@ -26,7 +26,11 @@
     aria-label={{ .label }}
   >
     <div class="tile__media" aria-hidden="true">
-      <img class="cover image" data-src="{{ if .context.Params.cover }} {{ .context.Params.cover }} {{ else }} {{ site.Params.defaultCover }} {{ end }}" alt="lt"/>
+      {{- $src := .context.Params.cover | default site.Params.defaultCover -}}
+      {{- with .context.Resources.GetMatch (printf "%s" ($src)) -}}
+          {{- $src = .RelPermalink -}}
+      {{- end -}}
+      <img class="cover image" data-src="{{ $src }}" alt="lt"/>
     </div>
 
     <div class="tile__description" aria-hidden="true">


### PR DESCRIPTION
Support using relative path for images in posts and tiles.

As mentioned in this issue:
#10 

With this patch, we can simply place images under the same folder as .md files.

For example, if we have this file structure:

```
content/
├── posts
│   ├── my-post
│   │   ├── preview.jpg
│   │   ├── image1.png
│   │   └── index.md
```

Then in the front matter of index.md, preview.jpg will work:

```
---
cover: "preview.jpg"
---
```

and image in the markdown also works:

`![my image](image1.png "test")`
