### PR TITLE
fix typo of the config in exampleSite

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -4,7 +4,7 @@ defaultContentLanguage = "en"
 hasCJKLanguage = true
 title = 'Apple Newsroom'
 copyright = 'Floyd Li'
-theme = 'iTheme'
+theme = 'hugo-theme-itheme'
 paginate = 5
 [params]
   defaultCover = 'https://www.apple.com.cn/newsroom/images/apple-logo_black.jpg.landing-regular_2x.jpg'


### PR DESCRIPTION
Change from "iTheme" to "hugo-theme-itheme"